### PR TITLE
Fix $ref strings treated as objects by JSONEditor

### DIFF
--- a/src/main/javascript/view/MainView.js
+++ b/src/main/javascript/view/MainView.js
@@ -74,7 +74,9 @@ SwaggerUi.Views.MainView = Backbone.View.extend({
     // is there any valid case were it should not be added ?
     var def;
     for(def in this.model.definitions){
-      this.model.definitions[def].type = 'object';
+      if (this.model.definitions[def].type === null){
+        this.model.definitions[def].type = 'object';
+      }
     }
 
   },


### PR DESCRIPTION
This is a fix for the issue referenced in the upstream PR:
https://github.com/swagger-api/swagger-ui/pull/1088#issuecomment-138307605

I haven't included the gulp rebuild because it seemed overly invasive.
It's possible it was done wrong, but for reference it's the HEAD here:
https://github.com/Thermeon/swagger-ui/tree/JSONEditor

HTH
